### PR TITLE
Add duration option; allows getting token only once.

### DIFF
--- a/src/awscli_login/__init__.py
+++ b/src/awscli_login/__init__.py
@@ -81,6 +81,17 @@ class Login(BasicCommand):
             'default': False,
             'help_text': 'Forces a login attempt to the IdP using cookies'
         },
+        {
+            'name': 'duration',
+            'default': None,
+            'help_text': 'time in seconds that the token will last'
+        },
+        {
+            'name': 'disable-refresh',
+            'default': False,
+            'cli_type_name': 'boolean',
+            'help_text': 'Disables automatic refresh of tokens'
+        },
     ]
 
     UPDATE = False

--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -58,6 +58,8 @@ class Profile:
     verbose = 0  # type: int
     refresh = 3000  # type: int
     force_refresh = False  # type: bool
+    duration = 0  # type: int
+    disable_refresh = False  # type: bool
 
     # path to profile configuration file
     config_file = None  # type: str
@@ -75,6 +77,8 @@ class Profile:
             'verbose': 0,
             'refresh': 3000,  # in seconds (every 50 mins)
             'force_refresh': False,
+            'duration': 0,  # duration can't be less than 900, btw
+            'disable_refresh': False
     }  # type: Dict[str, Any]
 
     _config_options = OrderedDict(

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -100,22 +100,29 @@ def remove_credentials(session: Session) -> None:
     """
     Removes current profile's credentials from ~/.aws/credentials.
     """
+
+    ConfigureSetCommand._WRITE_TO_CREDS_FILE.append("aws_security_token")
     profile = session.profile if session.profile else 'default'
 
     _aws_set(session, 'aws_access_key_id', '')
     _aws_set(session, 'aws_secret_access_key', '')
     _aws_set(session, 'aws_session_token',  '')
+    _aws_set(session, 'aws_security_token', '')
     logger.info("Removed temporary STS credentials from profile: " + profile)
 
 
 def save_credentials(session: Session, token: Dict) -> datetime:
     """ Takes an Amazon token and stores it in ~/.aws/credentials """
+
+    ConfigureSetCommand._WRITE_TO_CREDS_FILE.append("aws_security_token")
+
     creds = token['Credentials']
     profile = session.profile if session.profile else 'default'
 
     _aws_set(session, 'aws_access_key_id', creds['AccessKeyId'])
     _aws_set(session, 'aws_secret_access_key', creds['SecretAccessKey'])
     _aws_set(session, 'aws_session_token',  creds['SessionToken'])
+    _aws_set(session, 'aws_security_token',  creds['SessionToken'])
     logger.info("Saved temporary STS credentials to profile: " + profile)
 
     assert isinstance(creds['Expiration'], datetime), \


### PR DESCRIPTION
Addresses #6 somewhat.  if duration is set, daemon will not run so token will not refresh. Duration is also passed in assume_role_with_saml if given.

I started using this plugin yesterday and from what I can tell, these changes don't affect how anything currently works.  Profiles without duration continue to function normally.