### PR TITLE
Give users a way to name accounts shown in the selection list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,31 @@ the IdP session expires::
             [ 1 ]: IAMUser
     Selection: 0
 
+If you want to show an account alias in the list of
+roles, you can generate one with::
+
+    $ aws login account_names --save
+
+This will write a file to ``~/.aws-login/accounts.ini`` that you can edit
+as needed. If you rerun the command it will add any accounts that do
+not exist, but will not change existing entries.
+
+If you want to display the account alias on your shell prompt it is stored in
+``~/.aws-login/identity.txt`` and updated as you log in / out. You can use that
+file with a bash function like this::
+
+    aws_prompt_info() {
+        local IDENTITY_FILE=~/.aws-login/identity.txt
+        local PROF=""
+
+        if [[ -f "$IDENTITY_FILE" ]] then
+
+            PROF=$( cat "$IDENTITY_FILE" 2>/dev/null)
+            [[ -n "$PROF" ]] && echo "[$PROF]"
+        fi
+    }
+
+
 Advanced Example
 -------------------
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 ignore_missing_imports=True
 warn_redundant_casts=True
-# strict_optional=True
+strict_optional=False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-awscli-login==0.1.0a5
 boto3==1.6.4
 botocore==1.12.130
 certifi==2018.1.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli-login==0.1.0a5
 boto3==1.6.4
-botocore==1.9.4
+botocore==1.12.130
 certifi==2018.1.18
 chardet==3.0.4
 docutils==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-awscli-login==0.1.0
+awscli-login==0.1.0a5
 boto3==1.6.4
 botocore==1.9.4
 certifi==2018.1.18

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='co-awscli-login',
-    version='0.1.0a6',  # TODO change this to a git tag for Drone
+    version='0.1.0a7',  # TODO change this to a git tag for Drone
     description='Plugin for the AWS CLI that retrieves and rotates '
     'credentials using SAML ECP and STS.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='awscli-login',
+    name='co-awscli-login',
     version='0.1.0a6',  # TODO change this to a git tag for Drone
     description='Plugin for the AWS CLI that retrieves and rotates '
     'credentials using SAML ECP and STS.',

--- a/src/awscli_login/__init__.py
+++ b/src/awscli_login/__init__.py
@@ -10,6 +10,7 @@ from botocore.session import Session
 from .__main__ import main, logout
 from .configure import configure
 from .account_names import print_account_names, save_account_names
+
 logger = logging.getLogger(__package__)
 
 

--- a/src/awscli_login/__init__.py
+++ b/src/awscli_login/__init__.py
@@ -9,7 +9,7 @@ from botocore.session import Session
 
 from .__main__ import main, logout
 from .configure import configure
-
+from .account_names import print_account_names, save_account_names
 logger = logging.getLogger(__package__)
 
 
@@ -32,6 +32,7 @@ def inject_subcommands(command_table, session: Session, **kwargs):
     Used to inject subcommands into the aws login command list.
     """
     command_table['configure'] = Configure(session)
+    command_table['account_names'] = AccountNames(session)
 
 
 class Login(BasicCommand):
@@ -177,4 +178,55 @@ To update just the entity ID::\n
 
     def _run_main(self, args: Namespace, parsed_globals):
         configure(args, self._session)
+        return 0
+
+class AccountNames(BasicCommand):
+    NAME = 'account_names'
+    DESCRIPTION = ('''
+Print account names and account IDs
+=======================
+Configuration Variables
+=======================
+
+''')
+    SYNOPSIS = ('aws login account_names')
+
+    ARG_TABLE = [
+        {
+            'name': 'verbose',
+            'action': 'count',
+            'default': 0,
+            'cli_type_name': 'integer',
+            'help_text': 'Display verbose output'
+        },
+        {
+            'name': 'save',
+            'action': 'store_true',
+            'default': False,
+            'cli_type_name': 'boolean',
+            'help_text': 'Update accounts.ini file with names'
+        },
+    ]
+
+    EXAMPLES = ('''
+To create a new configuration::\n
+\n
+    $ aws login configure
+    Entity ID [None]: urn:mace:incommon:idp.edu
+    ECP Endpoint URL [None]: https://idp.edu/idp/profile/SAML2/SOAP/ECP\n
+\n
+To update just the entity ID::\n
+\n
+    $ aws login configure
+    Entity ID [urn:mace:incommon:idp.edu]: urn:mace:uncommon:foo.com
+    ECP Endpoint URL [https://idp.edu/idp/profile/SAML2/SOAP/ECP]:
+''')
+
+    def _run_main(self, args: Namespace, parsed_globals):
+
+        if args.save:
+            save_account_names(args, self._session)
+        else:
+            print_account_names(args, self._session)
+
         return 0

--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -96,7 +96,7 @@ def daemonize(profile: Profile, session: Session, client: boto3.client,
                     else:
                         break
 
-                expires = save_sts_token(session, client, saml, role)
+                expires = save_sts_token(session, client, saml, role, None)
 
         return is_parent
 

--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -31,7 +31,8 @@ from .util import (
     nap,
     remove_credentials,
     save_credentials,
-    write_identity_file
+    write_identity_file,
+    remove_identity_file
 )
 from .typing import Role
 
@@ -192,3 +193,6 @@ def logout(profile: Profile, session: Session):
         remove_credentials(session)
     except IOError:
         raise AlreadyLoggedOut
+    finally:
+        remove_identity_file()
+        

--- a/src/awscli_login/account_names.py
+++ b/src/awscli_login/account_names.py
@@ -1,0 +1,89 @@
+from botocore.session import Session
+import boto3
+from .__main__ import error_handler, save_sts_token
+from .util import sort_roles
+from .config import Profile
+from .saml import (
+    authenticate,
+    refresh
+)
+import os
+import configparser
+
+accountsfile = os.path.join(
+                         os.path.expanduser("~"),
+                         '.aws-login',
+                         'accounts.ini'
+                        )
+
+
+@error_handler()
+def print_account_names(profile: Profile, session: Session):
+    print(list_account_names(profile,session))
+
+
+@error_handler()
+def save_account_names(profile: Profile, session: Session):
+    names = list_account_names(profile, session)
+    write_account_names_file(names)
+
+def read_account_names_file():
+    account_names = {}
+    print(accountsfile)
+    if os.path.exists(accountsfile):
+        config = configparser.ConfigParser()
+        config.read(accountsfile)
+        for key in config['ACCOUNT_NAMES']:
+            account_names[key] = config['ACCOUNT_NAMES'][key]
+    return account_names
+
+def write_account_names_file(account_names):
+    config = configparser.ConfigParser()
+    if os.path.exists(accountsfile):
+        config.read(accountsfile)
+
+    if not config.has_section("ACCOUNT_NAMES"):
+        config.add_section("ACCOUNT_NAMES")
+
+    for account_id in account_names:
+        if not config.has_option("ACCOUNT_NAMES", account_id):
+            config.set("ACCOUNT_NAMES",account_id, account_names[account_id])
+
+    with open(accountsfile,'w') as f:
+        config.write(f)
+
+def list_account_names(profile: Profile, session: Session):
+    """ Print account names to STDOUT """
+    
+    sts = boto3.client('sts')
+    # creds = profile.get_credentials()
+    saml, roles = refresh(profile.ecp_endpoint_url,
+                               profile.cookies)
+
+    account_roles = [account_id for account_id, _ in sort_roles(roles)]
+    discovered = {}
+    for account_id, role  in list(zip(account_roles,roles)):
+        save_sts_token(session, sts, saml, role, profile.duration)
+
+        params = dict(
+            RoleArn=role[1],
+            PrincipalArn=role[0],
+            SAMLAssertion=saml,
+        )
+        # duration is optional and can be set by the role;
+        # avoid passing if not set.
+
+        token = sts.assume_role_with_saml(**params)
+        creds = token['Credentials']
+        iam = boto3.client(
+                'iam',
+                aws_access_key_id=creds['AccessKeyId'],
+                aws_secret_access_key=creds['SecretAccessKey'],
+                aws_session_token=creds['SessionToken']
+        )
+
+        aliases = iam.list_account_aliases()
+        default_alias = aliases['AccountAliases'][0]
+        discovered[account_id] = default_alias
+
+    return discovered

--- a/src/awscli_login/saml.py
+++ b/src/awscli_login/saml.py
@@ -216,7 +216,7 @@ def authn_request() -> bytes:
     Returns:
         A SOAP byte string.
     """
-    now = utcnow().strftime('%Y-%m-%dT%H:%M:%S')
+    now = utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     uuid = '_' + str.upper(str(uuid4())).replace('-', '')
 
     SOAP = "{%s}" % ns['S']

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -142,9 +142,10 @@ def remove_credentials(session: Session) -> None:
     _aws_set(session, 'aws_secret_access_key', '')
     _aws_set(session, 'aws_session_token',  '')
     _aws_set(session, 'aws_security_token', '')
-    os.remove(identityfile)
     logger.info("Removed temporary STS credentials from profile: " + profile)
 
+def remove_identity_file():
+    os.remove(identityfile)
 
 def save_credentials(session: Session, token: Dict) -> datetime:
     """ Takes an Amazon token and stores it in ~/.aws/credentials """

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -14,6 +14,7 @@ from .const import ERROR_INVALID_PROFILE_ROLE
 from .exceptions import SAML
 from .typing import Role
 
+## WHY CAN'T I IMPORT util or __main__ ??
 awsconfigfile = path.join('.aws', 'credentials')
 accountsfile = path.join(
                          os.path.expanduser("~"),

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import configparser
 
 from datetime import datetime, timezone
 from os import path
@@ -14,7 +15,11 @@ from .exceptions import SAML
 from .typing import Role
 
 awsconfigfile = path.join('.aws', 'credentials')
-
+accountsfile = path.join(
+                         os.path.expanduser("~"),
+                         '.aws-login',
+                         'accounts.ini'
+                        )
 logger = logging.getLogger(__name__)
 
 TRUE = ("yes", "true", "t", "1")
@@ -58,10 +63,23 @@ def get_selection(role_arns: List[Role], profile_role: str = None) -> Role:
 
     if n > 1:
         print("Please choose the role you would like to assume:")
+        account_names = {}
+        print(accountsfile)
+        if os.path.exists(accountsfile):
+            config = configparser.ConfigParser()
+            config.read(accountsfile)
+            for key in config['ACCOUNT_NAMES']:
+                account_names[key] = config['ACCOUNT_NAMES'][key]
 
         accounts = sort_roles(role_arns)
         for acct, roles in accounts:
-            print(' ' * 4, "Account:", acct)
+            if acct in account_names:
+                print(
+                        ' ' * 4,
+                        "Account: %s (%s)" % (account_names[acct], acct)
+                     )
+            else:
+                print(' ' * 4, "Account:", acct)
 
             for index, role in roles:
                 print(' ' * 8, "[ %d ]:" % i, role)

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -21,6 +21,27 @@ accountsfile = path.join(
                          '.aws-login',
                          'accounts.ini'
                         )
+
+identityfile = path.join(
+                         os.path.expanduser("~"),
+                         '.aws-login',
+                         'identity.txt'
+                        )
+def read_account_names_file():
+    account_names = {}
+    if os.path.exists(accountsfile):
+        config = configparser.ConfigParser()
+        config.read(accountsfile)
+        for key in config['ACCOUNT_NAMES']:
+            account_names[key] = config['ACCOUNT_NAMES'][key]
+    return account_names
+
+
+def write_identity_file(account_id):
+    account_names = read_account_names_file()
+    with open(identityfile,'w') as f:
+        print(account_names[account_id], file=f)
+
 logger = logging.getLogger(__name__)
 
 TRUE = ("yes", "true", "t", "1")
@@ -64,13 +85,7 @@ def get_selection(role_arns: List[Role], profile_role: str = None) -> Role:
 
     if n > 1:
         print("Please choose the role you would like to assume:")
-        account_names = {}
-        print(accountsfile)
-        if os.path.exists(accountsfile):
-            config = configparser.ConfigParser()
-            config.read(accountsfile)
-            for key in config['ACCOUNT_NAMES']:
-                account_names[key] = config['ACCOUNT_NAMES'][key]
+        account_names = read_account_names_file()
 
         accounts = sort_roles(role_arns)
         for acct, roles in accounts:
@@ -127,6 +142,7 @@ def remove_credentials(session: Session) -> None:
     _aws_set(session, 'aws_secret_access_key', '')
     _aws_set(session, 'aws_session_token',  '')
     _aws_set(session, 'aws_security_token', '')
+    os.remove(identityfile)
     logger.info("Removed temporary STS credentials from profile: " + profile)
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,8 @@
+Sphinx
+coverage
+sphinx-autodoc-typehints
+sphinx_rtd_theme
+tblib
+tox
+tox-pyenv
+wurlitzer


### PR DESCRIPTION
Fixes #18 
For some who have 70+ accounts that they need to manage & switch between picking an item in the list can be challenging because it just shows a bunch of numbers.

This change would let them drop an ini file into their .aws-login directory so they can override those account id with a meaningful name.

Notes:

- Sorry there's some extra changes, I had a really difficult time getting make to run until I figured out that I needed to install some other tools.
- I could not get unit tests to run, nor could I get `CONFIG_DIR` to import into `util.py` so that's why I duplicated the path. Happy to have some pointers to fix that.