### PR TITLE
Fix "Shiboleth" typo in config.py

### DIFF
--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -285,9 +285,9 @@ class Profile:
             self.raise_if_factor_invalid()
 
         if self.is_factor_valid():
-            headers['X-Shiboleth-Duo-Factor'] = self.factor
+            headers['X-Shibboleth-Duo-Factor'] = self.factor
             if not first_pass or self.factor == 'passcode':
-                headers['X-Shiboleth-Duo-Passcode'] = input('Code: ')
+                headers['X-Shibboleth-Duo-Passcode'] = input('Code: ')
 
         return self.username, self.password, headers
 


### PR DESCRIPTION
Keith mentioned it in https://marc.info/?l=shibboleth-users&m=155139152929633&w=2