### PR TITLE
Remove verbose property from config file

### DIFF
--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -115,7 +115,10 @@ def error_handler(skip_args=True, validate=False):
             sig = None
 
             try:
+                # verbosity can only be set at command line
                 configConsoleLogger(args.verbose)
+                del args.verbose
+
                 if not skip_args:
                     profile = Profile(session, args, validate)
                 else:

--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -55,7 +55,6 @@ class Profile:
     enable_keyring = False  # type: bool
     factor = None  # type: Optional[str]
     passcode = None  # type: str
-    verbose = 0  # type: int
     refresh = 3000  # type: int
     force_refresh = False  # type: bool
     duration = 0  # type: int
@@ -76,7 +75,6 @@ class Profile:
             'enable_keyring': False,
             'factor': None,
             'passcode': None,
-            'verbose': 0,
             'refresh': 3000,  # in seconds (every 50 mins)
             'force_refresh': False,
             'duration': 0,  # duration can't be less than 900, btw

--- a/src/tests/config/test_profile.py
+++ b/src/tests/config/test_profile.py
@@ -220,7 +220,6 @@ factor = push
 role_arn = arn:aws:iam::account-id:role/role-name
 enable_keyring = True
 passcode = secret_code
-verbose = 1
 refresh = 1500
     """
 
@@ -236,7 +235,6 @@ refresh = 1500
             "role_arn": "arn:aws:iam::account-id:role/role-name",
             "enable_keyring": True,
             "passcode": "secret_code",
-            "verbose": 1,
             "refresh": 1500,
         }
 
@@ -255,7 +253,6 @@ class ReadFullProfileTestOverrides(ReadFullProfile):
             "factor": 'sms',
             "role_arn": "arn:aws:iam::account-id:role/role-name2",
             "passcode": "secret",
-            "verbose": 2,
             "refresh": 1000,
         }  # Dict[str, Any]
         expected_attr_vals = copy(args)


### PR DESCRIPTION
In previous releases verbose could be set in the config file but it had no
effect.