### PR TITLE
Remove old debugging code

### DIFF
--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -133,8 +133,6 @@ def error_handler(skip_args=True, validate=False):
             except SIGTERM:
                 sig = 'SIGTERM'
             except Exception as e:
-                traceback.print_exc()
-
                 exc_info = sys.exc_info()
                 code = ERROR_UNKNOWN
                 exp = e


### PR DESCRIPTION
In the previous release, on an unknown exception the error_handler
printed the traceback directly to stdout. This was left in by mistake
during development.

Now as before an error message is logged to error, and the traceback
is logged to debug. The traceback can be seen by a user by passing
the flag --verbose twice.