### PR TITLE
Fix broken refresh property and flag

### DIFF
--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -80,7 +80,7 @@ def daemonize(profile: Profile, session: Session, client: boto3.client,
             # TODO add retries!
             while(True):
                 retries = 0
-                nap(expires, 0.9)
+                nap(expires, 0.9, profile.refresh)
 
                 while(True):
                     try:
@@ -93,7 +93,7 @@ def daemonize(profile: Profile, session: Session, client: boto3.client,
 
                         if (retries < 4):
                             logger.info('Refresh failed: %s' % str(e))
-                            nap(expires, 0.2)
+                            nap(expires, 0.2, profile.refresh * 0.2)
                         else:
                             raise
                     else:

--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -55,7 +55,7 @@ class Profile:
     enable_keyring = False  # type: bool
     factor = None  # type: Optional[str]
     passcode = None  # type: str
-    refresh = 3000  # type: int
+    refresh = 0  # type: int
     force_refresh = False  # type: bool
     duration = 0  # type: int
     disable_refresh = False  # type: bool
@@ -75,7 +75,7 @@ class Profile:
             'enable_keyring': False,
             'factor': None,
             'passcode': None,
-            'refresh': 3000,  # in seconds (every 50 mins)
+            'refresh': 0,  # in seconds
             'force_refresh': False,
             'duration': 0,  # duration can't be less than 900, btw
             'disable_refresh': False,

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -146,11 +146,14 @@ def file2str(filename: str) -> str:
     return data
 
 
-def nap(expires: datetime, percent: float) -> None:
+def nap(expires: datetime, percent: float, refresh: float = None) -> None:
     """TODO. """
-    tz = timezone.utc
-    ttl = int((expires - datetime.now(tz)).total_seconds())
-    sleep_for = ttl * 0.9
+    if refresh:
+        sleep_for = refresh
+    else:
+        tz = timezone.utc
+        ttl = int((expires - datetime.now(tz)).total_seconds())
+        sleep_for = ttl * percent
 
     logger.info('Going to sleep for %d seconds.' % sleep_for)
     sleep(sleep_for)


### PR DESCRIPTION
In previous releases the refresh value set via the config file or command
line was ignored. This is no longer the case.