### PR TITLE
Fix duration type error

### DIFF
--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -48,7 +48,9 @@ def save_sts_token(session: Session, client: boto3.client, saml: str,
         SAMLAssertion=saml,
     )
     if duration:
-        params['DurationSeconds'] = str(duration)
+        # Mypy reports that DurationSeconds should be a string but
+        # botocore dies unless it is an int so ignore mypy.
+        params['DurationSeconds'] = duration  # type: ignore[assignment]
         # duration is optional and can be set by the role;
         # avoid passing if not set.
 


### PR DESCRIPTION
The duration was being casted to a str from an int. During testing
I found that botocore throws a ParamValidationError if duration is
of type str. Passing the duration as an int resolves the error.

Closes #38