### PR TITLE
Allow cli flags to set logically False values

### DIFF
--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -137,7 +137,8 @@ class Profile:
         for option in options:
             value = getattr(self._args, option)
 
-            if value:
+            # Allow False, empty strings, zero, etc.
+            if value is not None:
                 setattr(self, option, value)
 
     def _set_override_attrs(self) -> None:

--- a/src/tests/config/test_profile.py
+++ b/src/tests/config/test_profile.py
@@ -222,6 +222,10 @@ enable_keyring = True
 passcode = secret_code
 verbose = 1
 refresh = 1500
+duration = 900
+disable_refresh = True
+http_header_factor = X_Foo
+http_header_passcode = X_Bar
     """
 
     def test_full_config(self) -> None:
@@ -238,6 +242,10 @@ refresh = 1500
             "passcode": "secret_code",
             "verbose": 1,
             "refresh": 1500,
+            "duration": 900,
+            "disable_refresh": True,
+            "http_header_factor": "X_Foo",
+            "http_header_passcode": "X_Bar",
         }
 
         self.assertProfileHasAttrs(**expected_attr_vals)
@@ -257,6 +265,32 @@ class ReadFullProfileTestOverrides(ReadFullProfile):
             "passcode": "secret",
             "verbose": 2,
             "refresh": 1000,
+            "duration": 1500,
+            "disable_refresh": True,
+            "http_header_factor": "X_Bar",
+            "http_header_passcode": "X_Foo",
+        }  # Dict[str, Any]
+        expected_attr_vals = copy(args)
+        expected_attr_vals.update({'enable_keyring': False})
+        args.update({'ask_password': True})
+
+        self.Profile(profile='default', no_args=False, **args)
+        self.assertProfileHasAttrs(**expected_attr_vals)
+
+    def test_logically_false_args_full_config(self) -> None:
+        """ Testing logically False command line args override config. """
+        args = {
+            "ecp_endpoint_url": '',
+            "username": '',
+            "password": '',
+            "factor": '',
+            "role_arn": "",
+            "passcode": "",
+            "refresh": 0,
+            "duration": 0,
+            "disable_refresh": False,
+            "http_header_factor": "",
+            "http_header_passcode": "",
         }  # Dict[str, Any]
         expected_attr_vals = copy(args)
         expected_attr_vals.update({'enable_keyring': False})


### PR DESCRIPTION
During testing, `--disable-refresh False` failed to override the
default True value. This fix changes the logic so that properties
are overwritten as long as an argument is not None. Before it only
overwrote a property if an argument value was logically True. This
bug effects every command line argument that overrides a property.