### PR TITLE
Add invalid selection error message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Release History
 `Unreleased`_
 -------------
 
+Changed
+```````
+
+* invalid selection now issues a fatal error message `#71`_
+
 `0.2b1`_ 2021-02-04
 ---------------------
 
@@ -81,3 +86,4 @@ Fixed
 .. _#62: https://github.com/techservicesillinois/awscli-login/pull/62
 .. _#64: https://github.com/techservicesillinois/awscli-login/pull/64
 .. _#66: https://github.com/techservicesillinois/awscli-login/pull/66
+.. _#71: https://github.com/techservicesillinois/awscli-login/pull/71

--- a/src/awscli_login/exceptions.py
+++ b/src/awscli_login/exceptions.py
@@ -86,3 +86,11 @@ class RoleParseFail(SAML):
     def __init__(self, role: str) -> None:
         mesg = "Bad SAML Response! Failed to parse role: %s!"
         super().__init__(mesg % role)
+
+
+class InvalidSelection(ConfigError):
+    code = 11
+
+    def __init__(self) -> None:
+        mesg = "Invalid selection!\a"
+        super().__init__(mesg)

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -10,7 +10,10 @@ from awscli.customizations.configure.set import ConfigureSetCommand
 from botocore.session import Session
 
 from .const import ERROR_INVALID_PROFILE_ROLE
-from .exceptions import SAML
+from .exceptions import (
+    InvalidSelection,
+    SAML,
+)
 from .typing import Role
 
 awsconfigfile = path.join('.aws', 'credentials')
@@ -69,8 +72,10 @@ def get_selection(role_arns: List[Role], profile_role: str = None) -> Role:
                 i += 1
 
         print("Selection:\a ", end='')
-# TODO need error checking
-        return role_arns[select[int(input())]]
+        try:
+            return role_arns[select[int(input())]]
+        except (ValueError, KeyError):
+            raise InvalidSelection
     elif n == 1:
         return role_arns[0]
     else:

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -11,7 +11,10 @@ from unittest.mock import patch
 from botocore.session import Session
 
 from awscli_login.const import ERROR_INVALID_PROFILE_ROLE
-from awscli_login.exceptions import SAML
+from awscli_login.exceptions import (
+    InvalidSelection,
+    SAML,
+)
 from awscli_login.util import (
     get_selection,
     remove_credentials,
@@ -129,6 +132,30 @@ class util(unittest.TestCase):
         ]
 
         self.assertEqual(get_selection(roles), roles[1])
+
+    @patch('builtins.input', return_value=3)
+    @patch('sys.stdout', new=StringIO())
+    def test_get_bad_numeric_selection(self, *args):
+        """ Invalid numeric selection of two roles """
+        roles = [
+            ('idp1', 'arn:aws:iam::123577191723:role/KalturaAdmin'),
+            ('idp2', 'arn:aws:iam::271867855970:role/BoxAdmin'),
+        ]
+
+        with self.assertRaises(InvalidSelection):
+            get_selection(roles)
+
+    @patch('builtins.input', return_value="foo")
+    @patch('sys.stdout', new=StringIO())
+    def test_get_bad_type_selection(self, *args):
+        """ Invalid string selection of two roles """
+        roles = [
+            ('idp1', 'arn:aws:iam::123577191723:role/KalturaAdmin'),
+            ('idp2', 'arn:aws:iam::271867855970:role/BoxAdmin'),
+        ]
+
+        with self.assertRaises(InvalidSelection):
+            get_selection(roles)
 
     @patch('builtins.input', return_value=1)
     def test_selections_profile_role(self, *args):


### PR DESCRIPTION
In previous releases an invalid selection caused a traceback to be
printed to the user. In the current release no error message is
displayed. With this commit an error message is issued to the user
on an invalid selection. This is sufficient since the user does not
need to reauthenticate on additional login attempts.