### PR TITLE
Drop boto3 dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changed
 
 * invalid selection now issues a fatal error message `#71`_
 
+Fixed
+`````
+* drop boto3 dependency that conflicts with awscliv2 `#73`_
+
 `0.2b1`_ 2021-02-04
 ---------------------
 
@@ -87,3 +91,4 @@ Fixed
 .. _#64: https://github.com/techservicesillinois/awscli-login/pull/64
 .. _#66: https://github.com/techservicesillinois/awscli-login/pull/66
 .. _#71: https://github.com/techservicesillinois/awscli-login/pull/71
+.. _#73: https://github.com/techservicesillinois/awscli-login/pull/73

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     python_requires='>=3.5',
     install_requires=[
        'awscli',
-       'boto3',
        'botocore',
        'daemoniker',
        'keyring',

--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -9,9 +9,8 @@ from datetime import datetime
 from functools import wraps
 from typing import Optional
 
-import boto3
-
 from botocore.session import Session
+from botocore import client as Client
 from daemoniker import Daemonizer, SignalHandler1
 from daemoniker import send, SIGINT, SIGTERM, SIGABRT
 
@@ -44,7 +43,7 @@ from .typing import Role
 logger = logging.getLogger(__package__)
 
 
-def save_sts_token(session: Session, client: boto3.client, saml: str,
+def save_sts_token(session: Session, client: Client, saml: str,
                    role: Role, duration: int = 0) -> datetime:
     params = dict(
         RoleArn=role[1],
@@ -64,7 +63,7 @@ def save_sts_token(session: Session, client: boto3.client, saml: str,
     return save_credentials(session, token)
 
 
-def daemonize(profile: Profile, session: Session, client: boto3.client,
+def daemonize(profile: Profile, session: Session, client: Client,
               role: Role, expires: datetime) -> bool:
     with Daemonizer() as (is_setup, daemonizer):
         is_parent, profile, session, client, role, expires = daemonizer(
@@ -179,7 +178,7 @@ def main(profile: Profile, session: Session):
         logger.warn("Logged out: ignoring --force-refresh.")
 
     try:
-        client = boto3.client('sts')
+        client = session.create_client('sts')
 
         # Exit if already logged in
         profile.raise_if_logged_in()

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -7,6 +7,7 @@ from time import sleep
 from typing import Dict, List, Tuple
 
 from awscli.customizations.configure.set import ConfigureSetCommand
+from botocore.utils import parse_timestamp
 from botocore.session import Session
 
 from .const import ERROR_INVALID_PROFILE_ROLE
@@ -130,9 +131,7 @@ def save_credentials(session: Session, token: Dict) -> datetime:
     _aws_set(session, 'aws_security_token',  creds['SessionToken'])
     logger.info("Saved temporary STS credentials to profile: " + profile)
 
-    assert isinstance(creds['Expiration'], datetime), \
-        "Amazon returned bad Expiration!"
-    return creds['Expiration']
+    return parse_timestamp(creds['Expiration'])
 
 
 def file2bytes(filename: str) -> bytes:

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 
-from datetime import datetime, timezone
 from io import StringIO
 from multiprocessing import get_start_method
 from os.path import isfile
@@ -33,7 +32,7 @@ def token(akey: str, skey: str, stoken: str) -> Dict[str, Dict[str, Any]]:
                                   'AccessKeyId': akey,
                                   'SecretAccessKey': skey,
                                   'SessionToken': stoken,
-                                  'Expiration': datetime.now(timezone.utc)
+                                  'Expiration': '2021-02-11T00:42:09Z'
                               }
            }
 


### PR DESCRIPTION
Removing boto3 because it is completely unnecessary, and incompatible
with awscliv2 (See link below). botocore is being used instead where
boto3 was used before.

https://github.com/boto/boto3/issues/2571

Fixes #37
Fixes #44