### PR TITLE
Automate Github Actions' Cache Invalidation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,8 +88,8 @@ jobs:
       id: date
       run: echo "::set-output name=week::$(date '+%U')"
 
-    - name: Cache tox virtualenv
-      id: tox
+    - name: Cache tox virtualenv & wheel cache
+      id: ghcache
       uses: actions/cache@v2
       with:
         path: |
@@ -97,19 +97,30 @@ jobs:
             **/cache
         key: ${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('**/setup.py', '**/tox.ini') }}-${{ steps.date.outputs.week }}-${{ secrets.CACHE_VERSION }}
 
-    # touch cache and tox env so make will not rebuild them
-    - name: Update timestamps
-      if: steps.tox.outputs.cache-hit == 'true'
-      run: touch -c cache .tox/wheel/pyvenv.cfg
-      shell: bash
+    - name: Validate tox virtualenv
+      uses: techservicesillinois/cache-validation@v1
+      id: tox
+      with:
+        path: .tox
+        cache_hit: ${{ steps.ghcache.outputs.cache-hit }}
+        remove_invalid_paths: true
+        touch: true
+
+    - name: Validate wheel cache
+      uses: techservicesillinois/cache-validation@v1
+      id: cache
+      with:
+        path: cache
+        cache_hit: ${{ steps.ghcache.outputs.cache-hit }}
+        remove_invalid_files: true
+        touch: true
 
     - name: Install system dependencies
-      if: matrix.os == 'ubuntu-latest' && steps.tox.outputs.cache-hit != 'true'
+      if: matrix.os == 'ubuntu-latest' && steps.cache.outputs.valid != 'true'
       run: |
         sudo apt-get install -y libxml2-dev libxslt-dev
 
     - name: Upgrade pip
-      if: steps.tox.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --upgrade-strategy eager pip
 
@@ -118,11 +129,11 @@ jobs:
         python -m pip install --upgrade --upgrade-strategy eager tox wheel
 
     - name: Update Python wheel cache
-      if: steps.tox.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.valid != 'true'
       run: make cache
 
     - name: Install
-      if: steps.tox.outputs.cache-hit != 'true'
+      if: steps.tox.outputs.valid != 'true'
       run: make install
 
     - name: Installed dependencies

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ deps-win: deps
 
 # Python packages needed to build a wheel
 deps-build: deps-publish
-	$(PIP) setuptools tox wheel flake8 mypy
+	$(PIP) setuptools tox wheel flake8 mypy types-requests
 
 # Python packages needed to build the documentation
 deps-doc:

--- a/src/tests/util.py
+++ b/src/tests/util.py
@@ -139,6 +139,12 @@ def exec_awscli(*argv: str) -> None:
     """ Run the aws cli. """
     @patch('sys.argv', ['aws', *argv])
     def run_main():
+        # Suppress deprecation warnings that can occur when Python
+        # compiles awscli. This is the normal behavior of the aws
+        # utility and prevents the logout unit tests from failing.
+        # https://github.com/techservicesillinois/awscli-login/pull/75
+        import warnings
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         main()
 
     run_main()


### PR DESCRIPTION
 From time to time the cached virtual environments become corrupted
requiring a cache invalidation. This commit adds automatic cache
invalidation that does not require manual intervention by a repository
administrator.

- Adds a cache-validation action to validate paths using MD5 hashes
- Adds a workflow to run unit tests for the cache-validation action
- Adds cache validation to the primary Github workflow