### PR TITLE
Added anticipated end of life - based on AWSCLI V1 and Python 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,12 @@ Windows are supported with limitations (See `Windows Issues`_).
 This product is supported by the Cybersecurity Development team at the 
 University of Illinois, on a best-effort basis. As of the last update to 
 this README, the expected End-of-Life and End-of-Support dates of this 
-product are 05 October 2025.
+version are October, 2025.
 
 The End-of-Life was decided upon based on these dependencies::
 
-+ AWSCLI V1 (End-of-Life is the same as Python V3)
-+ Python V3.9 (05 October 2025)
++ AWS CLI V1 (End-of-Life is the same as Python V3)
++ `Python V3.9 (October, 2025) <https://www.python.org/dev/peps/pep-0596/#lifespan>`_
 
 .. |--| unicode:: U+2013   .. en dash
 .. contents:: Jump to:

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Windows are supported with limitations (See `Windows Issues`_).
 This product is supported by the Cybersecurity Development team at the 
 University of Illinois, on a best-effort basis. As of the last update to 
 this README, the expected End-of-Life and End-of-Support dates of this 
-version are October, 2025, the same as its primary dependencies: the 
+version are October of 2025, the same as its primary dependencies: the 
 AWS CLI and 
 `Python V3.9 <https://www.python.org/dev/peps/pep-0596/#lifespan>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,9 @@ Windows are supported with limitations (See `Windows Issues`_).
 This product is supported by the Cybersecurity Development team at the 
 University of Illinois, on a best-effort basis. As of the last update to 
 this README, the expected End-of-Life and End-of-Support dates of this 
-version are October, 2025.
-
-The End-of-Life was decided upon based on these dependencies::
-
-+ AWS CLI V1 (End-of-Life is the same as Python V3)
-+ `Python V3.9 (October, 2025) <https://www.python.org/dev/peps/pep-0596/#lifespan>`_
+version are October, 2025, the same as its primary dependencies: the 
+AWS CLI and 
+`Python V3.9 <https://www.python.org/dev/peps/pep-0596/#lifespan>`_.
 
 .. |--| unicode:: U+2013   .. en dash
 .. contents:: Jump to:

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,16 @@ Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/about>`_.
 Currently, Windows PowerShell, Command Prompt, and Git Shell for
 Windows are supported with limitations (See `Windows Issues`_).
 
+This product is supported by the Cybersecurity Development team at the 
+University of Illinois, on a best-effort basis. As of the last update to 
+this README, the expected End-of-Life and End-of-Support dates of this 
+product are 05 October 2025.
+
+The End-of-Life was decided upon based on these dependencies::
+
++ AWSCLI V1 (End-of-Life is the same as Python V3)
++ Python V3.9 (05 October 2025)
+
 .. |--| unicode:: U+2013   .. en dash
 .. contents:: Jump to:
    :depth: 1


### PR DESCRIPTION
Adds an End-of-Life and End-of-Support date, matching that of Python 3.9 to our README.

This date will be updated as we merge updates to this product that increase it's expected lifespan.