### PR TITLE
Added steps to setup inside WSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,15 @@ so we recommend ensuring setuptools is up to date before installing.::
     $ pip install --upgrade setuptools
     $ pip install awscli-login
 
+If installing within WSL (Windows Subsystem for Linux) use the following steps,
+to launch within a Python virtual environment.::
+
+    $ virtualenv -p python3 venv
+    $ source venv/bin/activate
+    $ pip3 install awscli
+    $ pip3 install --upgrade setuptools
+    $ pip3 install awscli-login
+
 After awscli-login has been installed, run the following command
 to enable the plugin::
 


### PR DESCRIPTION
Not sure if this is everyone or just me but I was getting bad interpreter errors with how WSL was mapping python within my WSL environment trying to follow the instructions as is. Using a Python virtual environment I was able to install the plug-in and log into AWS.

Very real chance this note belongs elsewhere in the documentation.