### PR TITLE
New verify_ssl_certificate option

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -332,6 +332,11 @@ http_header_passcode
 
         http_header_passcode = X-Shibboleth-Duo-Passcode
 
+verify_ssl_certificate
+    Whether to verify the SSL certificate from the IdP. Defaults to true.
+
+        verify_ssl_certificate = True
+
 Command line arguments
 ======================
 

--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -63,6 +63,7 @@ class Profile:
     disable_refresh: bool = False
     http_header_factor: str
     http_header_passcode: str
+    verify_ssl_certificate: bool = True
 
     # path to profile configuration file
     config_file: str
@@ -82,6 +83,7 @@ class Profile:
             'disable_refresh': False,
             'http_header_factor': None,
             'http_header_passcode': None,
+            'verify_ssl_certificate': True,
     }
 
     _cli_only: Dict[str, Any] = {

--- a/src/awscli_login/plugin/__init__.py
+++ b/src/awscli_login/plugin/__init__.py
@@ -105,6 +105,12 @@ class Login(BasicCommand):
             'default': None,
             'help_text': 'HTTP Header to store the user\'s Duo passcode'
         },
+        {
+            'name': 'verify-ssl-certificate',
+            'default': None,
+            'cli_type_name': 'boolean',
+            'help_text': 'Verifies the SSL certificate of the IdP'
+        },
         # CLI only
         {
             'name': 'ask-password',
@@ -197,6 +203,7 @@ file:
 * **duration** - Time in seconds credentials are valid
 * **http_header_factor** - HTTP Header to store Duo factor
 * **http_header_passcode** - HTTP Header to store passcode
+* **verify_ssl_certificate** - Set to False to skip check of IdP SSL cert
 ''')
     SYNOPSIS = ('aws login configure')
 

--- a/src/awscli_login/plugin/__main__.py
+++ b/src/awscli_login/plugin/__main__.py
@@ -73,6 +73,7 @@ def daemonize(profile: Profile, session: Session, client: Client,
                             saml, _ = refresh(
                                 profile.ecp_endpoint_url,
                                 profile.cookies,
+                                profile.verify_ssl_certificate,
                             )
                         except Exception as e:
                             retries += 1
@@ -118,11 +119,13 @@ def main(profile: Profile, session: Session):
             saml, roles = refresh(
                 profile.ecp_endpoint_url,
                 profile.cookies,
+                profile.verify_ssl_certificate,
             )
         except Exception:
             creds = profile.get_credentials()
             saml, roles = authenticate(profile.ecp_endpoint_url,
-                                       profile.cookies, *creds)
+                                       profile.cookies, *creds,
+                                       profile.verify_ssl_certificate)
 
         duration = profile.duration
         role = get_selection(roles, profile.role_arn)

--- a/src/awscli_login/saml.py
+++ b/src/awscli_login/saml.py
@@ -24,6 +24,9 @@ from .exceptions import (
 from ._typing import Role, Headers
 from .util import secure_touch
 
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3 import disable_warnings
+
 SAML_SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success"
 
 ns = {
@@ -65,7 +68,8 @@ def raise_if_saml_failed(soap: bytes) -> None:
 
 def saml_login(url: str, jar: LWPCookieJar,
                username: Optional[str] = None, password: Optional[str] = None,
-               headers: Optional[Headers] = None) -> bytes:
+               headers: Optional[Headers] = None, verify_cert: bool = True,
+               ) -> bytes:
     """
     Generates and posts a SAML AuthNRequest to an IdP.
 
@@ -74,10 +78,15 @@ def saml_login(url: str, jar: LWPCookieJar,
         username: Username to provide to the IdP.
         password: Password to provide to the IdP.
         headers: optional headers to provide to the IdP.
+        verify_cert: whether to verify IdP SSL cert
 
     Returns:
         The SOAP response from the IdP.
     """
+
+    if not verify_cert:
+        disable_warnings(InsecureRequestWarning)
+
     s = Session()
     s.cookies = cast(RequestsCookieJar, jar)
     s.headers.update({'Content-Type': 'text/xml', 'charset': 'utf-8'})
@@ -86,7 +95,8 @@ def saml_login(url: str, jar: LWPCookieJar,
     auth = (username, password) if username and password else None
     logger.debug("POST %r\nheaders: %r\npayload %r" %
                  (url, headers, envelope))
-    r = s.post(url, data=envelope, headers=headers, auth=auth)
+    r = s.post(url, data=envelope, headers=headers, auth=auth,
+               verify=verify_cert)
     logger.debug("POST returned: %r" % r.content)
 
     r.raise_for_status()
@@ -99,7 +109,8 @@ def saml_login(url: str, jar: LWPCookieJar,
 
 def authenticate(url: str, cookies: str,
                  username: str, password: str,
-                 headers: Headers) -> Tuple[str, List[Role]]:
+                 headers: Headers,
+                 verify_cert: bool = True) -> Tuple[str, List[Role]]:
     """
     Authenitcate with user credentials to IdP.
 
@@ -109,13 +120,14 @@ def authenticate(url: str, cookies: str,
         username: Username to provide to the IdP.
         password: Password to provide to the IdP.
         headers: Optional headers to provide to the IdP.
+        verify_cert: whether to verify IdP SSL cert
 
     Returns:
         A base 64 encoded SAML assertion string, and a list of
         tuples containing a SAML provider ARN and a Role ARN.
     """
     jar = LWPCookieJar(cookies)
-    soap = saml_login(url, jar, username, password, headers)
+    soap = saml_login(url, jar, username, password, headers, verify_cert)
 
     mesg = "Successfully authenticated with username/password"
     logger.info(mesg + " to endpoint: " + url)
@@ -127,13 +139,15 @@ def authenticate(url: str, cookies: str,
     return parse_soap_response(soap)
 
 
-def refresh(url: str, cookies: str) -> Tuple[str, List[Role]]:
+def refresh(url: str, cookies: str,
+            verify_cert: bool = True) -> Tuple[str, List[Role]]:
     """
     Reauthenticate with cookies to IdP.
 
     Args:
         url: ECP endpoint URL for the IdP.
         cookies: A path to a cookie jar.
+        verify_cert: whether to verify IdP SSL cert
 
     Returns:
         A base 64 encoded SAML assertion string, and a list of
@@ -146,7 +160,7 @@ def refresh(url: str, cookies: str) -> Tuple[str, List[Role]]:
     except FileNotFoundError:
         raise MissingCookieJar(url)
 
-    soap = saml_login(url, jar)
+    soap = saml_login(url, jar, verify_cert=verify_cert)
 
     mesg = "Successfully authenticated with cookies"
     logger.info(mesg + " to endpoint: " + url)

--- a/src/tests/util.py
+++ b/src/tests/util.py
@@ -115,6 +115,7 @@ def login_cli_args(
     duration=None,
     http_header_factor=None,
     http_header_passcode=None,
+    verify_ssl_certificate=True,
     # CLI only
     ask_password=False,
     force_refresh=False,


### PR DESCRIPTION
* Allows skip of IdP SSL cert check when testing against a test IdP with a self-signed cert