### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6","3.7","3.8","3.9","3.10"]
+        python-version: ["3.7","3.8","3.9","3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -71,20 +71,19 @@ tox: .python-version build | cache
 	tox --installpkg $(WHEEL)
 
 .python-version:
-	pyenv install -s 3.6.12
 	pyenv install -s 3.7.13
 	pyenv install -s 3.8.13
 	pyenv install -s 3.9.13
 	pyenv install -s 3.10.5
-	pyenv local 3.6.12 3.7.13 3.8.13 3.9.13 3.10.5
+	pyenv local 3.7.13 3.8.13 3.9.13 3.10.5
 
 # Run tests on multiple versions of Python (Windows only)
 win-tox: .win-tox build | cache
 	tox --installpkg $(WHEEL)
 
 .win-tox:
-	pyenv install 3.5.4 3.6.8 3.7.9 3.8.7 3.9.1
-	python scripts/windows_bat.py 3.5.4 3.6.8 3.7.9 3.8.7 3.9.1
+	pyenv install 3.7.9 3.8.7 3.9.1
+	python scripts/windows_bat.py 3.7.9 3.8.7 3.9.1
 	touch $@
 
 # Run tests against wheel installed in virtualenv

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -48,7 +47,7 @@ setup(
     keywords='Amazon AWS SAML login access keys',
     packages=find_packages('src', exclude=['tests.*', 'tests']),
     package_dir={'': 'src'},
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
        'awscli',
        'botocore',

--- a/src/tests/config/test_get_credentials.py
+++ b/src/tests/config/test_get_credentials.py
@@ -94,48 +94,16 @@ class GetCredsProfileBase(ProfileBase):
         )
 
         if inputs.password:
-            try:  # Python 3.6 only
-                mock_password.assert_called_once()
-            except AttributeError:
-                self.assertEqual(
-                    1,
-                    mock_password.call_count
-                )
+            mock_password.assert_called_once()
         else:
-            try:  # Python 3.6 only
-                mock_password.assert_not_called()
-            except AttributeError:
-                self.assertEqual(
-                    0,
-                    mock_password.call_count
-                )
+            mock_password.assert_not_called()
 
         if self.profile.enable_keyring:
-            try:  # Python 3.6 only
-                mock_get_password.assert_called_once()
-                mock_set_password.assert_called_once()
-            except AttributeError:
-                self.assertEqual(
-                    1,
-                    mock_get_password.call_count
-                )
-                self.assertEqual(
-                    1,
-                    mock_set_password.call_count
-                )
+            mock_get_password.assert_called_once()
+            mock_set_password.assert_called_once()
         else:
-            try:
-                mock_get_password.assert_not_called()
-                mock_set_password.assert_not_called()
-            except AttributeError:
-                self.assertEqual(
-                    0,
-                    mock_get_password.call_count
-                )
-                self.assertEqual(
-                    0,
-                    mock_set_password.call_count
-                )
+            mock_get_password.assert_not_called()
+            mock_set_password.assert_not_called()
 
     def _test_get_credentials(self, outputs: Creds) -> None:
         usr, pwd, hdr = self.profile.get_credentials()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 
 [testenv]
 # getpass.getuser fails on Windows if these envs are not passed in


### PR DESCRIPTION
awscli v1 no longer supports Python 3.6 as of 5/30/2022:

https://github.com/aws/aws-cli/blob/develop/UPGRADE_PY3.md