### PR TITLE
Correct documentation typos

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -282,7 +282,7 @@ passcode
 
     It is not recommended to store a passcode in your configuration
     file since a passcode can only be used once. A passcode is
-    better passed interactivally or by the ``--passcode`` command
+    better passed interactively or by the ``--passcode`` command
     line flag.
 role_arn
     The role ARN to select. If the IdP returns a single role it is
@@ -350,7 +350,7 @@ with a corresponding command line option. Properties that contain
 an underscore will have a corresponding option with hyphens, for
 example the property ecp_endpoint_url becomes ``--ecp-endpoint-url``.
 For details on these options see the documentation above or refer
-to the online documentation. Options not avaliable as properties
+to the online documentation. Options not available as properties
 are documented below.
 
 options
@@ -432,7 +432,7 @@ Command line flag ``--ecp-endpoint-url`` error parsing parameter
 ----------------------------------------------------------------
 
 If you encounter the following error it is because the awscli expects
-urls passed as arguments to return a 200 on an HTTP GET (See
+URLs passed as arguments to return a 200 on an HTTP GET (See
 `aws-cli#4473 <https://github.com/aws/aws-cli/issues/4473>`_)::
 
     $ aws login --ecp-endpoint-url https://shibboleth.illinois.edu/idp/profile/SAML2/SOAP/ECP
@@ -460,7 +460,7 @@ be because you have a space in the path of your Python interpreter::
 
 To fix this issue either reinstall your Python interpreter to a
 path that does not contain a space and then reinstall the awscli
-package, or more simply just define an alias in your bashrc file::
+package, or more simply just define an alias in your `~/.bashrc` file::
 
     alias aws='python $(which aws)'
 

--- a/src/awscli_login/exceptions.py
+++ b/src/awscli_login/exceptions.py
@@ -32,7 +32,7 @@ class ProfileNotFound(ConfigError):
     def __init__(self, profile: str) -> None:
         super().__init__(f'The login profile {profile} could not be found!\n'
                          'Configure the profile with the following command:'
-                         f'aws login configure --profile {profile}')
+                         f'\n\naws login configure --profile {profile}')
 
 
 class ProfileMissingArgs(ConfigError):

--- a/src/awscli_login/plugin/__init__.py
+++ b/src/awscli_login/plugin/__init__.py
@@ -44,7 +44,7 @@ class Login(BasicCommand):
     # tests/util.py:login_cli_args defaults must match this table
     ARG_TABLE = [
         # Ordering matches order in docs/readme.rst
-        # Basic Properites (can be set interactively)
+        # Basic Properties (can be set interactively)
         {
             'name': 'ecp-endpoint-url',
             'default': None,
@@ -76,7 +76,7 @@ class Login(BasicCommand):
             'help_text': 'The Role ARN to select. '
                          'If the IdP returns a single Role it is autoselected.'
         },
-        # Advancded Properites (can NOT be set interactively)
+        # Advanced Properties (can NOT be set interactively)
         {
             'name': 'disable-refresh',
             'default': None,
@@ -147,7 +147,7 @@ class Logout(BasicCommand):
     NAME = 'logout'
     DESCRIPTION = ("Kills the process that renews the user's"
                    " credentials.")
-    SYNOPSIS = ('aws logut')
+    SYNOPSIS = ('aws logout')
 
     ARG_TABLE = [
         {
@@ -185,7 +185,7 @@ Configuration Variables
 The following configuration variables are supported in the config
 file:
 
-* **ecp_endpoint_url** - The ECP endpoint URL of the IDP to use for authn
+* **ecp_endpoint_url** - The ECP endpoint URL of the IDP to use for AuthN
 * **username** - The username to use on login to the IdP.
 * **password** - The password to use on login to the IdP.
 * **factor** - The Duo factor to use for 2FA

--- a/src/tests/cli/test_logout.py
+++ b/src/tests/cli/test_logout.py
@@ -25,8 +25,8 @@ class TestNoProfile(IntegrationTests):
         get_start_method() != 'fork',
         "This platform does not suppport fork!"
     )
-    def test_save_credentials_default_profile(self):
-        """ Creates a default entry in ~/.aws/credentials """
+    def test_login_configure_default_profile(self):
+        """ Creates a default entry in ~/.aws-login/config """
         calls = [
             call('ECP Endpoint URL [None]: '),
             call('Username [None]: '),

--- a/src/tests/test_configure.py
+++ b/src/tests/test_configure.py
@@ -13,8 +13,8 @@ class TestNoProfile(CleanTestEnvironment):
     profile = None  # default
 
     @patch('builtins.input', return_value='')
-    def test_save_credentials_default_profile(self, mock_input):
-        """ Creates a default entry in ~/.aws/credentials """
+    def test_login_configure_default_profile(self, mock_input):
+        """ Creates a default entry in ~/.aws-login/config """
         args = login_cli_args()
         session = Session()
         code = configure(args, session)


### PR DESCRIPTION
* Add newlines to ProfileNotFound error message for readability
* Rename test `test_save_credentials_default_profile` to
   `test_login_configure_default_profile` for accuracy
