### PR TITLE
Change exit to return or sys.exit

### DIFF
--- a/src/awscli_login/plugin/__init__.py
+++ b/src/awscli_login/plugin/__init__.py
@@ -130,8 +130,7 @@ class Login(BasicCommand):
     UPDATE = False
 
     def _run_main(self, args: Namespace, parsed_globals):
-        main(args, self._session)
-        return 0
+        return main(args, self._session)
 
 
 class Logout(BasicCommand):
@@ -153,8 +152,7 @@ class Logout(BasicCommand):
     UPDATE = False
 
     def _run_main(self, args: Namespace, parsed_globals):
-        logout(args, self._session)
-        return 0
+        return logout(args, self._session)
 
 
 class Configure(BasicCommand):
@@ -219,5 +217,4 @@ To update just the entity ID::\n
 ''')
 
     def _run_main(self, args: Namespace, parsed_globals):
-        configure(args, self._session)
-        return 0
+        return configure(args, self._session)

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -170,7 +170,7 @@ def _error_handler(Profile, skip_args=True, validate=False):
                 if sig:
                     logger.info('Received signal: %s. Shutting down...' % sig)
 
-                exit(code)
+                return code
 
         return wrapper
     return decorator

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -636,12 +636,9 @@ def _assertAwsCliReturns(args, calls):
         with pipes() as (out, err):
             try:
                 with patch('builtins.input', return_value='') as mock:
-                    exec_awscli(*args)
+                    t_code = exec_awscli(*args)
             except SystemExit as e:
                 t_code = e.code
-            else:
-                # This should never happen...
-                raise Exception("exec_awscli: Failed to raise SystemExit!")
 
         import sys
         cmd = ' '.join(sys.argv)

--- a/src/tests/test_configure.py
+++ b/src/tests/test_configure.py
@@ -17,10 +17,9 @@ class TestNoProfile(CleanTestEnvironment):
         """ Creates a default entry in ~/.aws/credentials """
         args = login_cli_args()
         session = Session()
-        with self.assertRaises(SystemExit) as e:
-            configure(args, session)
+        code = configure(args, session)
 
-        self.assertEqual(e.exception.code, 0)
+        self.assertEqual(code, 0)
         mock_input.assert_has_calls(
             [
                 call('ECP Endpoint URL [None]: '),

--- a/src/tests/util.py
+++ b/src/tests/util.py
@@ -1,3 +1,5 @@
+import sys
+
 from argparse import Namespace
 from functools import wraps
 from multiprocessing import Process, Pipe, set_start_method, get_start_method
@@ -78,7 +80,7 @@ def fork():
                     pickling_support.install()
                     etype, exp, tb = exc_info()
                     conn.send((etype, str(exp), tb))
-                    exit(1)
+                    sys.exit(1)
                 finally:
                     conn.close()
 
@@ -145,9 +147,9 @@ def exec_awscli(*argv: str) -> None:
         # https://github.com/techservicesillinois/awscli-login/pull/75
         import warnings
         warnings.filterwarnings("ignore", category=DeprecationWarning)
-        main()
+        return main()
 
-    run_main()
+    return run_main()
 
 
 # Based on code from:


### PR DESCRIPTION
* exit() should not be used in production code:
  https://docs.python.org/3/library/constants.html#exit