### PR TITLE
Add --save-http-traffic and --load-http-traffic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'test': [
             'tblib',
             'wurlitzer',
+            'vcrpy',
         ],
     },
     test_suite="tests",

--- a/src/awscli_login/exceptions.py
+++ b/src/awscli_login/exceptions.py
@@ -95,3 +95,39 @@ class InvalidSelection(ConfigError):
     def __init__(self) -> None:
         mesg = "Invalid selection!\a"
         super().__init__(mesg)
+
+
+class TooManyHttpTrafficFlags(ConfigError):
+    code = 12
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Can not specify both --save-http-traffic"
+            " and --load-http-traffic"
+        )
+
+
+class VcrFailedToLoad(ConfigError):
+    code = 13
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Failed to load vcr module. "
+            "Install vcr to use the --save_http_traffic\n"
+            "or --load_http_traffic flags:\n\n"
+            "    $ pip install vcrpy"
+        )
+
+
+class MissingTape(ConfigError):
+    code = 14
+
+    def __init__(self, filename) -> None:
+        super().__init__(f"{filename}: No such file")
+
+
+class ExistingTape(ConfigError):
+    code = 15
+
+    def __init__(self, filename) -> None:
+        super().__init__(f"{filename}: file or directory already exists")

--- a/src/awscli_login/plugin/__init__.py
+++ b/src/awscli_login/plugin/__init__.py
@@ -125,6 +125,16 @@ class Login(BasicCommand):
             'cli_type_name': 'integer',
             'help_text': 'Display verbose output'
         },
+        {
+            'name': 'save-http-traffic',
+            'default': None,
+            'help_text': 'Save http traffic to a file for debugging'
+        },
+        {
+            'name': 'load-http-traffic',
+            'default': None,
+            'help_text': 'Load http traffic from file for debugging'
+        },
     ]
 
     UPDATE = False


### PR DESCRIPTION
These flags allow us to perform integration testing from the command
line without network access. Further they allow easy debugging of
network traffic.