### PR TITLE
Remove implicit optional type hints

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,3 @@
 [mypy]
 ignore_missing_imports=True
 warn_redundant_casts=True
-# strict_optional=True

--- a/src/awscli_login/saml.py
+++ b/src/awscli_login/saml.py
@@ -6,7 +6,7 @@ import lxml.etree as ET
 from base64 import b64encode
 from datetime import datetime
 from http.cookiejar import LWPCookieJar
-from typing import List, Tuple
+from typing import Optional, List, Tuple
 from typing import cast
 from uuid import uuid4
 
@@ -64,8 +64,8 @@ def raise_if_saml_failed(soap: bytes) -> None:
 
 
 def saml_login(url: str, jar: LWPCookieJar,
-               username: str = None, password: str = None,
-               headers: Headers = None) -> bytes:
+               username: Optional[str] = None, password: Optional[str] = None,
+               headers: Optional[Headers] = None) -> bytes:
     """
     Generates and posts a SAML AuthNRequest to an IdP.
 

--- a/src/awscli_login/util.py
+++ b/src/awscli_login/util.py
@@ -44,7 +44,8 @@ def sort_roles(role_arns: List[Role]) \
     return r
 
 
-def get_selection(role_arns: List[Role], profile_role: str = None) -> Role:
+def get_selection(role_arns: List[Role], profile_role: Optional[str] = None
+                  ) -> Role:
     """ Interactively prompts the user for a role selection. """
     i = 0
     n = len(role_arns)
@@ -97,7 +98,8 @@ def file2str(filename: str) -> str:
     return data
 
 
-def nap(expires: datetime, percent: float, refresh: float = None) -> None:
+def nap(expires: datetime, percent: float, refresh: Optional[float] = None
+        ) -> None:
     """TODO. """
     if refresh:
         sleep_for = refresh

--- a/src/tests/config/test_get_credentials.py
+++ b/src/tests/config/test_get_credentials.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import List, Iterator
+from typing import Optional, List, Iterator
 
 from awscli_login.const import (
     DUO_HEADER_FACTOR,
@@ -12,9 +12,10 @@ from .base import ProfileBase
 
 class Creds():
 
-    def __init__(self, username: str = None, password: str = None,
-                 factor: str = None, passcode: str = None,
-                 keyring: str = None) -> None:
+    def __init__(self, username: Optional[str] = None,
+                 password: Optional[str] = None,
+                 factor: Optional[str] = None, passcode: Optional[str] = None,
+                 keyring: Optional[str] = None) -> None:
         self.username = username
         self.password = password
         self.factor = factor

--- a/src/tests/config/util.py
+++ b/src/tests/config/util.py
@@ -13,7 +13,7 @@ class MockSession:
     """
     profile: Optional[str] = None
 
-    def __init__(self, profile: str = None) -> None:
+    def __init__(self, profile: Optional[str] = None) -> None:
         self.profile = profile
 
 


### PR DESCRIPTION
* mypy versions newer than 0.982 no longer support implicit optional type hints causing the pipeline to fail. This commit updates all implicit optional type hints to be explicit per PEP 484.