### PR TITLE
Fix build system to support tox 4.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ all: test coverage docs doctest
 # Python dependencies needed for local development
 deps: deps-build deps-doc deps-test deps-publish
 
-# Python packages needed to run the tests on a Unix system
-deps-posix: deps
-	$(PIP) tox-pyenv
-
 # Python packages needed to run the tests on a Windows system
 deps-win: deps
 	$(PIP) pyenv-win
@@ -56,7 +52,7 @@ check: .twinecheck
 # Install wheel into tox virtualenv for testing
 install: $(TOX_ENV)
 $(TOX_ENV): build | cache
-	tox -e wheel --notest --installpkg $(WHEEL) -vv
+	tox -e wheel --notest --installpkg $(WHEEL)
 	@touch $@
 
 # Build and save dependencies for reuse

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py37,py38,py39,py310
 
 [testenv]
 # getpass.getuser fails on Windows if these envs are not passed in
-passenv = LOGNAME USER LNAME USERNAME
+passenv = LOGNAME,USER,LNAME,USERNAME
 # https://packaging.python.org/guides/index-mirrors-and-caches/#caching-with-pip
 install_command=python -m pip install --disable-pip-version-check --find-links=cache {opts} {packages}
 commands = python -m unittest discover -s src {posargs}


### PR DESCRIPTION
* Drop incompatible and unsupported tox-pyenv

Closes #126