### PR TITLE
Add sts_endpoint_url option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,13 @@ idp: .idp.docker
 	docker compose up -d
 	@touch $@
 
+# TODO: Is this right?
 idp-down:
 	docker compose down --rmi all
+	rm -f .idp.docker
+
+idp-clean:
+	docker-compose down --rmi=all
 	rm -f .idp.docker
 
 .install-build: $(RELEASE)
@@ -233,5 +238,5 @@ clean: idp-down
 	rm -rf build dist src/*.egg-info .eggs
 	make -C docs clean
 
-clean-all: clean
+clean-all: clean idp-clean
 	rm -rf cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,12 +33,11 @@ services:
      - INITIAL_NO_AUTH_ACTION_COUNT=0
     logging:
       options:
-         tag: "idp"
+         tag: "aws"
     networks:
      - front
-     - back
     ports:
-     - "8443:443"
+     - "5000:5000"
 
 networks:
   front:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,20 @@ services:
     ports:
      - "8443:443"
 
+  aws:
+    image: motoserver/moto:4.1.4
+    environment:
+     # Enable IAM. If not set everything is permitted.
+     - INITIAL_NO_AUTH_ACTION_COUNT=0
+    logging:
+      options:
+         tag: "idp"
+    networks:
+     - front
+     - back
+    ports:
+     - "8443:443"
+
 networks:
   front:
-  back:    
+  back:

--- a/docs/readme/body.rst
+++ b/docs/readme/body.rst
@@ -419,6 +419,13 @@ http_header_passcode
 
         http_header_passcode = X-Shibboleth-Duo-Passcode
 
+sts_endpoint_url
+    The endpoint URL to use to communicate with the AWS Security
+    Token Service (STS). Generally, only needed for testing and
+    debugging::
+
+        sts_endpoint_url = http://localhost:5000
+
 verify_ssl_certificate
     Whether to verify the SSL certificate from the IdP. Defaults to true.
 

--- a/src/awscli_login/__init__.py
+++ b/src/awscli_login/__init__.py
@@ -120,6 +120,12 @@ class Login(ExternalCommand):
             'help_text': 'HTTP Header to store the user\'s Duo factor'
         },
         {
+            'name': 'sts-endpoint-url',
+            'no_paramfile': True,
+            'default': None,
+            'help_text': 'AWS STS endpoint URL to retrieve credentials from'
+        },
+        {
             'name': 'http_header_passcode',
             'default': None,
             'help_text': 'HTTP Header to store the user\'s Duo passcode'
@@ -223,6 +229,7 @@ file:
 * **duration** - Time in seconds credentials are valid
 * **http_header_factor** - HTTP Header to store Duo factor
 * **http_header_passcode** - HTTP Header to store passcode
+* **sts_endpoint_url** - Set to override default AWS STS endpoint
 * **verify_ssl_certificate** - Set to False to skip check of IdP SSL cert
 ''')
     SYNOPSIS = ('aws login configure')

--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -48,7 +48,10 @@ def save_sts_token(profile: Profile, client: Client, saml: str,
 
 def login(profile: Profile, session: Session, interactive: bool = True):
     session.set_credentials(None, None)  # Disable credential lookup
-    client = session.create_client('sts')
+    client = session.create_client(
+        'sts',
+        endpoint_url=profile.sts_endpoint_url
+    )
 
     # Exit if already logged in
     if interactive:

--- a/src/awscli_login/config.py
+++ b/src/awscli_login/config.py
@@ -86,6 +86,7 @@ class Profile:
     http_header_factor: str
     http_header_passcode: str
     verify_ssl_certificate: bool = True
+    sts_endpoint_url: Optional[str]
 
     # path to profile configuration file
     config_file: str
@@ -108,6 +109,7 @@ class Profile:
             'http_header_factor': None,
             'http_header_passcode': None,
             'verify_ssl_certificate': True,
+            'sts_endpoint_url': None,
     }
 
     _cli_only: Dict[str, Any] = {

--- a/src/integration_tests/tests/common-docker-idp.bash
+++ b/src/integration_tests/tests/common-docker-idp.bash
@@ -4,6 +4,8 @@
 load 'base'
 eval "_base_$(declare -f setup)"  # Rename setup to _base_setup
 
+export LOGIN="login --sts-endpoint-url=http://127.0.0.1:5000 --verify-ssl-certificate=false --password password"
+
 setup() {
     _base_setup
 

--- a/src/integration_tests/tests/common-docker-idp.bash
+++ b/src/integration_tests/tests/common-docker-idp.bash
@@ -4,7 +4,10 @@
 load 'base'
 eval "_base_$(declare -f setup)"  # Rename setup to _base_setup
 
-export LOGIN="login --sts-endpoint-url=http://127.0.0.1:5000 --verify-ssl-certificate=false --password password"
+# TODO: Can we use add code so we can use --endpoint-url instead
+#       of --sts-endpoint-url?
+export LOGIN="login --sts-endpoint-url=http://localhost:5000 --verify-ssl-certificate=false --password password"
+export AWS="aws --endpoint-url=http://localhost:5000"
 
 setup() {
     _base_setup

--- a/src/integration_tests/tests/docker-idp-login.bats
+++ b/src/integration_tests/tests/docker-idp-login.bats
@@ -17,10 +17,21 @@ load 'common-docker-idp'
     run aws $LOGIN --ecp-endpoint-url 'https://localhost:8443/idp/profile/SAML2/SOAP/ECP'
     assert_success
     assert_output ""
+    assert_output ""
+}
+
+@test "Test no --sts-endpoint-url" {
+    # TODO: Revert to old "Login with Docker Id"
+    run aws $LOGIN
+    assert_success
+    assert_output ""
 }
 
 @test "Login with Docker IdP" {
-    run aws $LOGIN
+    run $AWS $LOGIN
     assert_success
+    assert_output ""
+
+    run $AWS sts get-caller-identity
     assert_output ""
 }

--- a/src/integration_tests/tests/docker-idp-login.bats
+++ b/src/integration_tests/tests/docker-idp-login.bats
@@ -11,17 +11,16 @@ load 'common-docker-idp'
 		
 	EOF
 
-    run aws login --verify-ssl-certificate=false --password password
+    run aws $LOGIN
     assert_failure
     assert_output "404 Client Error:  for url: https://localhost:8443/bad/endpoint"
-    run aws login --verify-ssl-certificate=false --password password \
-        --ecp-endpoint-url 'https://localhost:8443/idp/profile/SAML2/SOAP/ECP'
-    assert_failure
-    assert_output -e "An error occurred \(InvalidIdentityToken\) when calling the AssumeRoleWithSAML operation: Specified provider doesn't exist \(Service: AWSOpenIdDiscoveryService; Status Code: 400; Error Code: AuthSamlManifestNotFoundException; Request ID: [0-9a-f-]+; Proxy: null\)"
+    run aws $LOGIN --ecp-endpoint-url 'https://localhost:8443/idp/profile/SAML2/SOAP/ECP'
+    assert_success
+    assert_output ""
 }
 
 @test "Login with Docker IdP" {
-    run aws login --verify-ssl-certificate=false --password password
-    assert_failure
-    assert_output -e "An error occurred \(InvalidIdentityToken\) when calling the AssumeRoleWithSAML operation: Specified provider doesn't exist \(Service: AWSOpenIdDiscoveryService; Status Code: 400; Error Code: AuthSamlManifestNotFoundException; Request ID: [0-9a-f-]+; Proxy: null\)"
+    run aws $LOGIN
+    assert_success
+    assert_output ""
 }

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -19,6 +19,7 @@ class MockProfile():
     force_refresh = False
     name = 'default'
     verify_ssl_certificate = True
+    sts_endpoint_url = None
 
     def raise_if_logged_in(self):
         return
@@ -94,7 +95,7 @@ class Login(unittest.TestCase):
         """ Interactive login wo/refreshable creds should prompt user. """
         login(self.profile, self.session, interactive=True)
         self.session.set_credentials.assert_called_with(None, None)
-        self.session.create_client.assert_called_with("sts")
+        self.session.create_client.assert_called_with("sts", endpoint_url=None)
 
         self.profile.get_username.assert_called()
         refresh.assert_called_with(
@@ -129,7 +130,7 @@ class Login(unittest.TestCase):
         """ Interactive login w/refreshable creds should not prompt user. """
         login(self.profile, self.session, interactive=True)
         self.session.set_credentials.assert_called_with(None, None)
-        self.session.create_client.assert_called_with("sts")
+        self.session.create_client.assert_called_with("sts", endpoint_url=None)
 
         self.profile.get_username.assert_called()
         refresh.assert_called_with(
@@ -160,7 +161,7 @@ class Login(unittest.TestCase):
         """ A non interactive login should not prompt the user. """
         login(self.profile, self.session, interactive=False)
         self.session.set_credentials.assert_called_with(None, None)
-        self.session.create_client.assert_called_with("sts")
+        self.session.create_client.assert_called_with("sts", endpoint_url=None)
 
         self.profile.get_username.assert_not_called()
         refresh.assert_called_with(

--- a/src/tests/util.py
+++ b/src/tests/util.py
@@ -113,6 +113,7 @@ def login_cli_args(
     duration=None,
     http_header_factor=None,
     http_header_passcode=None,
+    sts_endpoint_url=None,
     verify_ssl_certificate=True,
     # CLI only
     ask_password=False,

--- a/test.env
+++ b/test.env
@@ -1,0 +1,32 @@
+# usage: source test.env
+#
+# Sets up a tempory directory & environment variables for testing
+# aws login
+
+disable () {
+    unset AWS_CONFIG_FILE
+    unset AWS_SHARED_CREDENTIALS_FILE
+    unset AWSCLI_LOGIN_ROOT
+    rm -rf $AWSCLI_LOGIN_ROOT
+
+    unalias aws
+    unalias login
+
+    unset -f disable
+}
+
+export AWSCLI_LOGIN_ROOT=`mktemp -d`
+export AWS_CONFIG_FILE="$AWSCLI_LOGIN_ROOT/.aws/config"
+export AWS_SHARED_CREDENTIALS_FILE="$AWSCLI_LOGIN_ROOT/.aws/credentials"
+
+aws configure set plugins.login awscli_login.plugin
+aws login configure >/dev/null <<- EOF  # NOTA BENE: <<- strips tabs
+	https://localhost:8443/idp/profile/SAML2/SOAP/ECP
+	user01
+	
+	push
+	
+EOF
+
+alias login="login --sts-endpoint-url=http://localhost:5000 --verify-ssl-certificate=false"
+alias aws="aws --endpoint-url=http://localhost:5000"


### PR DESCRIPTION
* Add AWS IAM container [moto](https://docs.getmoto.org/en/latest/docs/iam.html) to allow offline testing of awscli-login against the shibboleth IdP container
* Update integration tests to use the new container