### PR TITLE
Split slowest test into separate tox environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ win-tox: .win-tox build | cache
 # Run tests against wheel installed in virtualenv
 test: lint static check .coverage
 
+<<<<<<< HEAD
 idp: .idp.docker
 .idp.docker:
 	docker-compose up -d
@@ -102,6 +103,10 @@ else
 endif
 integration_tests: .install $(idp_integration_deps)
 	make -C src/integration_tests/
+
+test_fast: export AWSCLI_LOGIN_FAST_TEST_ONLY=1
+test_fast: .install
+	python -m unittest discover --failfast -s src
 
 # Run tests with coverage tool -- generates .coverage file
 .coverage: $(TOX_ENV) $(TSTS)
@@ -121,7 +126,7 @@ develop: lint static .install develop-coverage
 	@touch $@
 
 .coverage.develop: export COVERAGE_FILE=.coverage.develop
-.coverage.develop: $(MODULE_SRCS) $(TSTS)
+.coverage.develop: .install $(MODULE_SRCS) $(TSTS)
 	coverage run -m unittest discover -s src -v
 
 develop-coverage: export COVERAGE_FILE=.coverage.develop

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ win-tox: .win-tox build | cache
 # Run tests against wheel installed in virtualenv
 test: lint static check .coverage
 
-<<<<<<< HEAD
 idp: .idp.docker
 .idp.docker:
 	docker-compose up -d

--- a/src/tests/cli/test_logout.py
+++ b/src/tests/cli/test_logout.py
@@ -1,6 +1,7 @@
 # from contextlib import redirect_stdout, redirect_stderr
 # from io import StringIO
 import unittest
+import os
 
 from multiprocessing import get_start_method
 from unittest.mock import call
@@ -8,8 +9,13 @@ from unittest.mock import call
 from ..base import IntegrationTests
 
 
+@unittest.skipIf(
+    os.environ.get('AWSCLI_LOGIN_FAST_TEST_ONLY'), 'Skipping slow test')
 class TestNoProfile(IntegrationTests):
-    """ Integration tests for no profile. """
+    """ Integration tests for no profile.
+
+    This test takes about 2.16 seconds to run.
+    """
 
     @unittest.skipIf(
         get_start_method() != 'fork',


### PR DESCRIPTION
- Add unittest.skip tag to remove slowest test from unittest discovery and from coverage
- Add slowest test to dedicated tox testenv:slow
- Add make target for tox_slow