### PR TITLE
Add bats outputs test environ info for debugging

### DIFF
--- a/src/integration_tests/tests/clean.bash
+++ b/src/integration_tests/tests/clean.bash
@@ -12,6 +12,14 @@ setup() {
 }
 
 teardown() {
+  if [[ $BATSLIB_TEMP_PRESERVE_ON_FAILURE == '1' ]]; then
+    echo "To run tests in this test enviroment set the following variables:"
+    echo ""
+    echo "export AWS_CONFIG_FILE=\"$TEST_TEMP_DIR/.aws/config\""
+    echo "export AWS_SHARED_CREDENTIALS_FILE=\"$TEST_TEMP_DIR/.aws/credentials\""
+    echo "export AWSCLI_LOGIN_ROOT=\"$TEST_TEMP_DIR\""
+  fi
+
   temp_del "$TEST_TEMP_DIR"
 }
 


### PR DESCRIPTION
On error shell commands for setting up the environment varibles needed to repoduce a test are now outputed when bats is run in debug mode.