### PR TITLE
Fix failing Test PyPI releases

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Pushes to the default branch are not being released to Test PyPI as expected. This commit fixes a typo in the workflow that caused this bug.