### PR TITLE
Fix broken build

### DIFF
--- a/src/awscli_login/logger.py
+++ b/src/awscli_login/logger.py
@@ -7,11 +7,16 @@ def _cli_options(verbosity: int) -> Tuple[int, str]:
     fmt = '%(message)s'
     level = logging.WARN
 
+    # Suppress awscli syntax warnings #173
+    awscli = logging.getLogger("awscli")
+    awscli.setLevel(logging.ERROR)
+
     if verbosity == 1:
         level = logging.INFO
 
         urllib3 = logging.getLogger("urllib3")
         urllib3.setLevel(logging.DEBUG)
+        awscli.setLevel(logging.WARN)
 
     if verbosity == 2:
         level = logging.DEBUG
@@ -21,6 +26,7 @@ def _cli_options(verbosity: int) -> Tuple[int, str]:
 
         botocore = logging.getLogger("botocore.endpoint")
         botocore.setLevel(logging.DEBUG)
+        awscli.setLevel(logging.INFO)
 
     if verbosity == 3:
         fmt = '%(name)s %(message)s'

--- a/src/awscli_login/logger.py
+++ b/src/awscli_login/logger.py
@@ -7,16 +7,11 @@ def _cli_options(verbosity: int) -> Tuple[int, str]:
     fmt = '%(message)s'
     level = logging.WARN
 
-    # Suppress awscli syntax warnings #173
-    awscli = logging.getLogger("awscli")
-    awscli.setLevel(logging.ERROR)
-
     if verbosity == 1:
         level = logging.INFO
 
         urllib3 = logging.getLogger("urllib3")
         urllib3.setLevel(logging.DEBUG)
-        awscli.setLevel(logging.WARN)
 
     if verbosity == 2:
         level = logging.DEBUG
@@ -26,7 +21,6 @@ def _cli_options(verbosity: int) -> Tuple[int, str]:
 
         botocore = logging.getLogger("botocore.endpoint")
         botocore.setLevel(logging.DEBUG)
-        awscli.setLevel(logging.INFO)
 
     if verbosity == 3:
         fmt = '%(name)s %(message)s'

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -633,8 +633,8 @@ class IntegrationTests(CleanTestEnvironment):
         Args:
             *args (str): Arguments to be passed to the AWS command
                 line utility.
-            stdout (str): Expected output to stdout.
-            stderr (str): Expected output to stderr.
+            stdout (str): Expected output to stdout. Skip test if None.
+            stderr (str): Expected output to stderr. Skip test if None.
             code (int): Expected return code.
             calls (list(unittest.mock.call)): List of expected calls.
 
@@ -644,16 +644,19 @@ class IntegrationTests(CleanTestEnvironment):
         t_out, t_err, t_code, cmd = _assertAwsCliReturns(args, calls)
 
         mesg = "Error: ran '%s', on %s expected output: %s"
-        self.assertEqual(
-            t_out,
-            stdout,
-            mesg % (cmd, 'stdout', stdout)
-        )
-        self.assertEqual(
-            t_err,
-            stderr,
-            mesg % (cmd, 'stderr', stderr)
-        )
+
+        if stdout is not None:
+            self.assertEqual(
+                t_out,
+                stdout,
+                mesg % (cmd, 'stdout', stdout)
+            )
+        if stderr is not None:
+            self.assertEqual(
+                t_err,
+                stderr,
+                mesg % (cmd, 'stderr', stderr)
+            )
         self.assertEqual(
             t_code,
             code,

--- a/src/tests/cli/test_logout.py
+++ b/src/tests/cli/test_logout.py
@@ -41,4 +41,5 @@ class TestNoProfile(IntegrationTests):
             call('Role ARN [None]: '),
         ]
 
-        self.assertAwsCliReturns('login', 'configure', code=0, calls=calls)
+        self.assertAwsCliReturns('login', 'configure', code=0, stderr=None,
+                                 calls=calls)


### PR DESCRIPTION
Unit tests fail since awscli is throwing SyntaxWarnings. This commit turns down the logging level for messages coming from awscli.

Closes #173