### PR TITLE
Fix awscli_login.plugin is absent from pkg config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,4 @@ local_scheme = "dirty-tag"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["awscli_login"]
+include = ["awscli_login*"]


### PR DESCRIPTION
Closes #172