### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -153,8 +153,16 @@ jobs:
         python -m pip install --upgrade --upgrade-strategy eager tox wheel
 
     - name: Update Python wheel cache
-      if: steps.cache.outputs.valid != 'true'
+      if: steps.cache.outputs.valid != 'true' && matrix.os != 'macos-latest'
       run: make cache
+
+    # Compile lxml on ARM macOS systems to avoid bad wheels on PyPI.
+    # See issue #189.
+    - name: Update Python wheel cache (macOS)
+      if: steps.cache.outputs.valid != 'true' && matrix.os == 'macos-latest'
+      run: make cache
+      env:
+        PIP_NO_BINARY: 'lxml'
 
     - name: Install
       if: steps.tox.outputs.valid != 'true'

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HTML := htmlcov/index.html
 TOX := tox -e wheel -qq --skip-pkg-install
 TOX_ENV := .tox/wheel/pyvenv.cfg
 WHEEL := $(MODULE_NAME)-$(VERSION)-py3-none-any.whl
-SDIST := $(PACKAGE_NAME)-$(VERSION).tar.gz
+SDIST := $(MODULE_NAME)-$(VERSION).tar.gz
 RELEASE := dist/$(WHEEL) dist/$(SDIST)
 PIP := python -m pip install --upgrade --upgrade-strategy eager
 

--- a/docs/readme/body.rst
+++ b/docs/readme/body.rst
@@ -405,3 +405,16 @@ the location of a Windows install of awscli::
 To remedy this issue please ensure that the location where the
 awscli is installed in the WSL comes before the location of the
 Windows install in the WSL PATH environment variable.
+
+
+lxml import errors on macOS
+---------------------------
+
+On M1 and M2 Apple MacBooks you may receive the following error at runtime::
+
+    ImportError: dlopen(/Users/ddriddle/.pyenv/versions/3.8.16/lib/python3.8/site-packages/lxml/etree.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '_exsltDateXpathCtxtRegister'
+
+This can be fixed by removing and compiling lxml::
+
+    pip uninstall lxml
+    PIP_NO_BINARY=lxml pip install lxml

--- a/src/integration_tests/tests/build.bats
+++ b/src/integration_tests/tests/build.bats
@@ -11,6 +11,6 @@ setup() {
 }
 
 @test "Install from source distribution" {
-    run pip install --no-deps ../../dist/awscli-login*.tar.gz
+    run pip install --no-deps ../../dist/awscli_login*.tar.gz
     assert_success
 }


### PR DESCRIPTION
* Setuptools now requires that the source distribution filename contains no hyphens per PEP 625. The hyphens are replaced with an underscore.
* Compiles lxml in Github Actions on macOS
* Documents lxml workaround on macOS for end users

Closes #191 #189