### PR TITLE
Add macOS to Github Actions integration tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -191,7 +191,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8","3.9","3.10","3.11","3.12"]
 
     steps:
@@ -250,15 +250,8 @@ jobs:
     - name: Install integration test deps
       run: make deps-integration-test
 
-    - name: Integration Tests (POSIX)
-      if: matrix.os != 'windows-latest'
+    - name: Integration Tests
       run: make integration-tests
-
-    - name: Integration Tests (Windows)
-      if: matrix.os == 'windows-latest'
-      run: make integration-tests
-      env:
-        AWSCLI_LOGIN_WINDOWS_TEST: 1
 
   publish:
     needs: [unit_tests, integration_tests]

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,19 @@ idp-down:
 install-build: .install-build
 	pip install dist/$(WHEEL)
 
+# Some integration tests require Linux containers for the
+# IdP. HyperV is required by Docker but NOT supported by
+# Github Action's Windows VMs.
+# https://github.com/actions/runner-images/issues/2216
 ifeq ($(RUNNER_OS),Windows)
     idp_integration_deps=
+integration-tests: export AWSCLI_LOGIN_SKIP_DOCKER_TESTS=1
+integration-tests: export AWSCLI_LOGIN_WINDOWS_TEST=1
+# As of 9/13/2024, macos-latest does not support docker. This may
+# change by the end of the year. See issue #208.
+else ifeq ($(RUNNER_OS),macOS)
+    idp_integration_deps=
+integration-tests: export AWSCLI_LOGIN_SKIP_DOCKER_TESTS=1
 else
     idp_integration_deps=.idp.docker
 endif

--- a/src/integration_tests/tests/common-docker-idp.bash
+++ b/src/integration_tests/tests/common-docker-idp.bash
@@ -7,12 +7,8 @@ eval "_base_$(declare -f setup)"  # Rename setup to _base_setup
 setup() {
     _base_setup
 
-    # We cannot run integration tests dependent on Linux docker
-    # containers on Windows runners because GitHub Actions does not
-    # support Linux containers on Windows (See actions/runner-images#1143,
-    # actions/runner#904, and actions/runner-images#5760).
-    if [ $RUNNER_OS == "Windows" ]; then
-        skip "Windows runners do not support Docker IdP integration tests."
+    if [ -n "$AWSCLI_LOGIN_SKIP_DOCKER_TESTS" ]; then
+        skip "Docker is not installed or is disabled."
     fi
     
     aws login configure <<- EOF  # NOTA BENE: <<- strips tabs


### PR DESCRIPTION
* Skip Docker integration tests on macOS since Docker is not currently
supported
* Move logic for skipping Docker based integration tests from the
tests to the Makefile