### PR TITLE
Upgrade actions/{upload,download}-artifact to v4

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,7 +49,7 @@ jobs:
       run: make check
 
     - name: Archive build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build
         path: |
@@ -79,7 +79,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: build
 
@@ -178,7 +178,7 @@ jobs:
       run: make coverage report
 
     - name: Archive coverage report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ runner.os }}-py${{ matrix.python-version }}
         path: htmlcov
@@ -205,7 +205,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: build
 
@@ -286,7 +286,7 @@ jobs:
         make deps-publish
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: build
 


### PR DESCRIPTION
Correctly addresses v4 upgrade recommened by dependabot PR #206.