### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.9","3.10","3.11","3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v3
@@ -192,7 +192,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.9","3.10","3.11","3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v3
@@ -260,7 +260,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.9","3.10","3.11","3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Submit a [GitHub Issue](https://github.com/techservicesillinois/awscli-login/iss
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.9 or higher
 - [GNU Make](https://www.gnu.org/software/make/)
 
 ### Installation

--- a/Makefile
+++ b/Makefile
@@ -83,20 +83,20 @@ tox: .python-version $(RELEASE) | cache
 	tox --installpkg dist/$(WHEEL)
 
 .python-version:
-	pyenv install -s 3.8.16
-	pyenv install -s 3.9.16
-	pyenv install -s 3.10.9
-	pyenv install -s 3.11.1
-	pyenv install -s 3.12.0
-	pyenv local 3.8.16 3.9.16 3.10.9 3.11.1 3.12.0
+	pyenv install -s 3.9.21
+	pyenv install -s 3.10.16
+	pyenv install -s 3.11.11
+	pyenv install -s 3.12.9
+	pyenv install -s 3.13.2
+	pyenv local 3.9.21 3.10.16 3.11.11 3.12.9 3.13.2
 
 # Run tests on multiple versions of Python (Windows only)
 win-tox: .win-tox $(RELEASE) | cache
 	tox --installpkg dist/$(WHEEL)
 
 .win-tox:
-	pyenv install 3.8.7 3.9.1
-	python scripts/windows_bat.py 3.8.7 3.9.1
+	pyenv install 3.9.1
+	python scripts/windows_bat.py 3.9.1
 	touch $@
 
 # Run tests against wheel installed in virtualenv

--- a/docs/readme/header.rst
+++ b/docs/readme/header.rst
@@ -4,9 +4,9 @@ application is fully supported under Linux, macOS, and Windows.
 
 This product is supported by the Cybersecurity Development team at the 
 University of Illinois, on a best-effort basis. The expected End-of-Life
-and End-of-Support date of this version is October 2028, the same as
+and End-of-Support date of this version is October 2029, the same as
 its primary dependencies: the AWS CLI and 
-`Python V3.12 <https://peps.python.org/pep-0693/#lifespan>`_.
+`Python V3.13 <https://peps.python.org/pep-0719/#lifespan>`_.
 
 .. |--| unicode:: U+2013   .. en dash
 .. contents:: Jump to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ classifiers = [
     'Intended Audience :: System Administrators',
     'License :: OSI Approved :: MIT License',
     'Natural Language :: English',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.urls]
 Homepage = "https://github.com/techservicesillinois/awscli-login"

--- a/src/awscli_login/const.py
+++ b/src/awscli_login/const.py
@@ -7,3 +7,10 @@ OVERWRITE_PROFILE = "Overwrite profile '%s' to enable login? "
 
 DUO_HEADER_FACTOR = 'X-Shibboleth-Duo-Factor'
 DUO_HEADER_PASSCODE = 'X-Shibboleth-Duo-Passcode'
+
+ERROR_INVALID_CRED_PROC_PATH = \
+    "credential_process:%s: Is not on $PATH or not executable."
+ERROR_INVALID_CRED_PROC_WRONG_PROFILE_ARG = \
+    "credential_process:%s: --profile not set to current profile '%s'."
+ERROR_INVALID_CRED_PROC_MISSING_PROFILE_ARG = \
+    "credential_process:%s: --profile argument not set."

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py39,py310,py311,py312,py313
 
 [testenv]
 # getpass.getuser fails on Windows if these envs are not passed in


### PR DESCRIPTION
Add support for Python 3.13

* Add better error messages to raise_if_credential_process_not_set
* Drop support for Python 3.8

Close #218
Close #225
Close #233
Close #234