### PR TITLE
Fix CLI option underscores to hyphens

### DIFF
--- a/src/awscli_login/__init__.py
+++ b/src/awscli_login/__init__.py
@@ -122,12 +122,12 @@ class Login(ExternalCommand):
             'help_text': 'STS credential lifetime in seconds'
         },
         {
-            'name': 'http_header_factor',
+            'name': 'http-header-factor',
             'default': None,
             'help_text': 'HTTP Header to store the user\'s Duo factor'
         },
         {
-            'name': 'http_header_passcode',
+            'name': 'http-header-passcode',
             'default': None,
             'help_text': 'HTTP Header to store the user\'s Duo passcode'
         },


### PR DESCRIPTION
* Change cli flag `--http_header_factor` to `--http-header-factor`
* Change cli flag `--http_header_passcode` to `--http-header-passcode`

Closes #137