### PR TITLE
Add identity files for shell prompts

### DIFF
--- a/docs/readme/body.rst
+++ b/docs/readme/body.rst
@@ -290,6 +290,41 @@ does warn on accounts if the AWS IAM API does not return an alias::
     Unable to retrieve aliases for:
     520135271718
 
+If you want to display the account alias and role on your shell
+prompt they are stored in ``~/.aws-login/identity/PROFILE_NAME/acct``
+and in ``~/.aws-login/identity/PROFILE_NAME/role`` respectively.
+Both are updated as you log in and out. You can use one or both
+of these files with a bash function like this added to your ``~/.bashrc``
+file::
+
+    aws_acct() {
+        local IDENTITY_DIR="$HOME/.aws-login/identity/${AWS_PROFILE:-default}"
+        local ACCT_FILE="$IDENTITY_DIR/acct"
+        local ROLE_FILE="$IDENTITY_DIR/role"
+
+        if [[ -f "$ACCT_FILE" && -f "$ROLE_FILE" ]]; then
+            local ACCT="$(cat $ACCT_FILE 2>/dev/null)"
+            local ROLE="$(cat $ROLE_FILE 2>/dev/null)"
+            [[ -n "$ACCT" && -n "$ROLE" ]] && echo "[$ROLE@$ACCT] "
+        fi
+    }
+
+Append the following line to the end of your ``~/.bash_profile``::
+
+    export PS1="\$(aws_acct)$PS1"
+
+Your prompt should dynamically change on login and logout. For example::
+
+    $ aws login
+        Account: aws-foobar-prod (978517677611)
+            [ 0 ]: Admin
+        Account: aws-foobar-test (520135271718)
+            [ 1 ]: ReadOnlyUser
+            [ 2 ]: S3Admin
+    Selection: 2
+    [S3Admin@aws-foobar-test] $ aws logout
+    $
+
 Advanced Usage
 ==============
 

--- a/src/awscli_login/__main__.py
+++ b/src/awscli_login/__main__.py
@@ -82,6 +82,7 @@ def login(profile: Profile, session: Session, interactive: bool = True):
     duration = profile.duration
     role = get_selection(roles, profile.role_arn, interactive,
                          profile.account_names)
+    profile.write_identity_files(role)
     return save_sts_token(profile, client, saml, role, duration)
 
 
@@ -102,6 +103,7 @@ def logout(profile: Profile, session: Session, xargs: Namespace,
     else:
         if not profile.remove_credentials():
             raise AlreadyLoggedOut
+    profile.remove_identity_files()
 
 
 @error_handler(skip_args=False, validate=True)

--- a/src/tests/config/test_profile.py
+++ b/src/tests/config/test_profile.py
@@ -469,6 +469,31 @@ username = NetID
         self.assertEqual(self.profile.role_arn, "jane")
 
 
+class TestIdentityFiles(ProfileBase):
+
+    def test_write_read_remove_identity_files(self):
+        self.login_config = """
+[default]
+ecp_endpoint_url = url
+"""
+        self.Profile(profile='default', no_args=True)
+
+        self.assertFalse(path.exists(self.profile.identity_dir))
+        self.profile.write_identity_files([
+            "foo",
+            "blah:blah:blah:blah:1234:foo/bar:blah",
+        ])
+
+        self.assertTrue(path.exists(self.profile.identity_dir))
+        with open(self.profile.identity_acct_file, 'r') as f:
+            self.assertEqual('1234', f.read())
+        with open(self.profile.identity_role_file, 'r') as f:
+            self.assertEqual('bar', f.read())
+
+        self.profile.remove_identity_files()
+        self.assertFalse(path.exists(self.profile.identity_dir))
+
+
 # This ensures that shared tests in mixins are not run with empty
 # data sets!
 del CookieMixin

--- a/src/tests/login.py
+++ b/src/tests/login.py
@@ -23,6 +23,9 @@ class MockProfile():
     def raise_if_logged_out(self):
         return
 
+    def write_identity_files(self, role):
+        return
+
 
 class MockBotocoreClient():
     pass


### PR DESCRIPTION
Creates a file that contains the selected account name or ID on
login, and another file that contains the role name. Both are removed
on logout.

Co-authored-by: Chris Ortman <chris-ortman@uiowa.edu>

Closes https://github.com/techservicesillinois/awscli-login/issues/27